### PR TITLE
Updated le gem dependency to greater than 2.1.6  (le gem is now asynchro...

### DIFF
--- a/lib/sinatra-logentries/version.rb
+++ b/lib/sinatra-logentries/version.rb
@@ -1,5 +1,5 @@
 module Sinatra
   module Logentries
-    VERSION = "0.0.1"
+    VERSION = "0.0.2"
   end
 end

--- a/sinatra-logentries.gemspec
+++ b/sinatra-logentries.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |gem|
   gem.summary       = %q{Easy logging in Sinatra with Logentries}
   gem.homepage      = %q{http://github.com/tsantef/sinatra-logentries}
 
-  gem.add_dependency("le", "2.0")
+  gem.add_dependency("le", ">= 2.1.6")
   gem.files         = `git ls-files`.split($/)
   gem.executables   = gem.files.grep(%r{^bin/}).map{ |f| File.basename(f) }
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})


### PR DESCRIPTION
...nous)  Hey Tim, I've made some important updates to the le gem such as making it asynchronous. Just updated the sinatra-logentries gemspec touse le v2.1.6 and greater. 

Thanks,

Mark
