### PR TITLE
Add license to gemspec

### DIFF
--- a/sinatra-logentries.gemspec
+++ b/sinatra-logentries.gemspec
@@ -11,6 +11,7 @@ Gem::Specification.new do |gem|
   gem.description   = %q{Adds logging with Logentries}
   gem.summary       = %q{Easy logging in Sinatra with Logentries}
   gem.homepage      = %q{http://github.com/tsantef/sinatra-logentries}
+  gem.license       = %q{MIT}
 
   gem.add_dependency("le", ">= 2.1.6")
   gem.files         = `git ls-files`.split($/)


### PR DESCRIPTION
I was trying to determine the licenses for my dependencies. I found that the RubyGems API will return the license, but only if it is specified in your gemspec file.
